### PR TITLE
Add functional DEM and eval tests

### DIFF
--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -1,4 +1,4 @@
-"""Placeholder tests for DEM module."""
+"""Tests for the DEM (Data Efficiency Method) module."""
 
 from dem.train_individual import train_individual_domain
 from dem.vector_diff import compute_vector_diff
@@ -10,3 +10,37 @@ def test_dem_functions_exist() -> None:
     assert callable(train_individual_domain)
     assert callable(compute_vector_diff)
     assert callable(merge_models)
+
+
+def test_compute_vector_diff_basic() -> None:
+    """Verify simple difference calculation between two models."""
+    base = {"w1": 1.0, "w2": 2.0}
+    tuned = {"w1": 1.5, "w2": 3.0}
+
+    diff = compute_vector_diff(base, tuned)
+
+    assert diff == {"w1": 0.5, "w2": 1.0}
+
+
+def test_merge_models_additive() -> None:
+    """Ensure model merging adds diff vectors to the base model."""
+    base = {"w1": 1.0, "w2": 2.0}
+    diff1 = {"w1": 0.2, "w2": -0.5}
+    diff2 = {"w1": -0.1, "w2": 0.3}
+
+    merged = merge_models(base, [diff1, diff2])
+
+    expected = {"w1": 1.1, "w2": 1.8}
+    assert merged == expected
+
+
+def test_train_individual_domain_creates_output(tmp_path) -> None:
+    """Training function should create the given output directory."""
+    data_file = tmp_path / "sample.jsonl"
+    data_file.write_text('{"text": "hello"}\n', encoding="utf-8")
+    out_dir = tmp_path / "model"
+
+    result = train_individual_domain(str(data_file), str(out_dir))
+
+    assert out_dir.exists()
+    assert result is not None

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,4 +1,4 @@
-"""Placeholder tests for evaluation module."""
+"""Tests for the evaluation utilities."""
 
 from evaluation.compute_metrics import compute_metrics
 from evaluation.eval_runner import run_evaluation
@@ -8,3 +8,31 @@ def test_evaluation_functions_exist() -> None:
     """Check that evaluation functions are callable."""
     assert callable(compute_metrics)
     assert callable(run_evaluation)
+
+
+def test_compute_metrics_simple() -> None:
+    """Metrics should return scores for identical sentences."""
+    references = ["안녕하세요"]
+    predictions = ["안녕하세요"]
+
+    metrics = compute_metrics(references, predictions)
+
+    assert isinstance(metrics, dict)
+    assert metrics
+    assert all(isinstance(v, float) for v in metrics.values())
+
+
+def test_run_evaluation_smoke(monkeypatch) -> None:
+    """run_evaluation should invoke compute_metrics on prompts."""
+
+    called = {"count": 0}
+
+    def fake_compute_metrics(refs, preds):
+        called["count"] += 1
+        return {"bleu": 1.0}
+
+    monkeypatch.setattr("evaluation.eval_runner.compute_metrics", fake_compute_metrics)
+
+    run_evaluation(["테스트"])
+
+    assert called["count"] == 1


### PR DESCRIPTION
## Summary
- expand DEM tests for diff, merge and training functions
- extend evaluation tests to check metrics behavior and evaluation runner

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_6841115281008333ba87117e176ec50a