### PR TITLE
Update testing instructions and path setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,15 +170,17 @@ domain_weights:
 
 ## 🧪 테스트
 
+테스트 실행 시에는 저장소 루트를 `PYTHONPATH`에 추가해야 합니다.
+
 ```bash
 # 단위 테스트 실행
-pytest tests/
+PYTHONPATH=. pytest
 
 # 특정 모듈 테스트
-pytest tests/test_dedup.py
+PYTHONPATH=. pytest tests/test_dedup.py
 
 # 커버리지 포함 테스트
-pytest --cov=. tests/
+PYTHONPATH=. pytest --cov=.
 ```
 
 ## 📖 상세 문서

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""PyTest configuration to ensure repository root is on sys.path."""
+
+from pathlib import Path
+import sys
+
+repo_root = Path(__file__).resolve().parents[1]
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -8,8 +8,6 @@ import json
 import os
 from unittest.mock import Mock, patch, MagicMock
 
-import sys
-sys.path.append('..')
 
 from utils.cloud_storage import CloudStorageManager, get_storage_client
 from utils.data_utils import validate_jsonl_format


### PR DESCRIPTION
## Summary
- document running tests via `PYTHONPATH=. pytest`
- ensure tests import modules by adding `tests/conftest.py`
- remove outdated path hack in `test_cloud_storage.py`

## Testing
- `pytest -q` *(fails: AttributeError: <module 'utils.cloud_storage'> does not have the attribute 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_6841115130688333ac0bbbb606b444c9