### PR TITLE
Handle optional test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ domain_weights:
 
 테스트 실행 시에는 저장소 루트를 `PYTHONPATH`에 추가해야 합니다.
 
+일부 테스트는 `pandas`, `pyarrow`, `torch`, `bert_score` 등 선택적 의존성에
+의존합니다. 이러한 패키지가 설치되지 않은 경우 해당 테스트는 자동으로
+건너뛰어집니다. 전체 테스트를 실행하려면 다음과 같이 환경을 설정합니다.
+
+```bash
+pip install pandas pyarrow torch bert-score rouge-score sacrebleu
+```
+
 ```bash
 # 단위 테스트 실행
 PYTHONPATH=. pytest

--- a/scripts/test_loading_speed.py
+++ b/scripts/test_loading_speed.py
@@ -6,6 +6,10 @@ import argparse
 from pathlib import Path
 from time import perf_counter
 
+import pytest
+
+pytest.importorskip("pandas")
+
 import pandas as pd
 
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -1,5 +1,10 @@
-import torch
 """Tests for the DEM (Data Efficiency Method) module."""
+
+import pytest
+
+pytest.importorskip("torch")
+
+import torch
 
 from dem.train_individual import train_individual_domain
 from dem.vector_diff import compute_vector_diff

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,9 +1,14 @@
 """Tests for evaluation runner and metrics computation."""
 
 from unittest.mock import MagicMock, patch
-import sys
-sys.path.append('..')
+import pytest
+
+pytest.importorskip("bert_score")
+pytest.importorskip("rouge_score")
+pytest.importorskip("sacrebleu")
+
 from evaluation.eval_runner import run_evaluation
+from evaluation.compute_metrics import compute_metrics
 
 
 def test_run_evaluation_computes_metrics() -> None:
@@ -19,6 +24,8 @@ def test_run_evaluation_computes_metrics() -> None:
 
     assert metrics == {"score": 1.0}
     metric_mock.assert_called_once_with(["Hello"], ["merged"])
+
+
 def test_evaluation_functions_exist() -> None:
     """Check that evaluation functions are callable."""
     assert callable(compute_metrics)
@@ -36,7 +43,8 @@ def test_compute_metrics_non_zero_scores() -> None:
     assert scores["rougeL"] > 0
     assert scores["bert_score_f1"] > 0
 
-    def test_compute_metrics_simple() -> None:
+
+def test_compute_metrics_simple() -> None:
     """Metrics should return scores for identical sentences."""
     references = ["안녕하세요"]
     predictions = ["안녕하세요"]
@@ -49,7 +57,7 @@ def test_compute_metrics_non_zero_scores() -> None:
 
 
 def test_run_evaluation_smoke(monkeypatch) -> None:
-    """run_evaluation should invoke compute_metrics on prompts."""
+    """``run_evaluation`` should invoke ``compute_metrics`` on prompts."""
 
     called = {"count": 0}
 
@@ -59,6 +67,7 @@ def test_run_evaluation_smoke(monkeypatch) -> None:
 
     monkeypatch.setattr("evaluation.eval_runner.compute_metrics", fake_compute_metrics)
 
-    run_evaluation(["테스트"])
+    run_evaluation("base", "merged", "dummy.jsonl")
 
     assert called["count"] == 1
+

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,11 +1,9 @@
 """Placeholder tests for format module."""
 
-from unittest.mock import MagicMock
-import sys
+import pytest
 
-sys.modules.setdefault("pandas", MagicMock())
-sys.modules.setdefault("pyarrow", MagicMock())
-sys.modules.setdefault("pyarrow.parquet", MagicMock())
+pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
 
 from format.to_parquet import main as to_parquet_main  # type: ignore
 


### PR DESCRIPTION
## Summary
- skip test modules if optional dependencies are missing using `pytest.importorskip`
- document optional dependencies for tests in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411f3dc5c483338eca05c6f6c5928f