### PR TITLE
Fix indent for metrics simple test

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -45,7 +45,6 @@ def test_compute_metrics_non_zero_scores() -> None:
     assert scores["rougeL"] > 0
     assert scores["bert_score_f1"] > 0
 
-
 def test_compute_metrics_simple() -> None:
     """Metrics should return scores for identical sentences."""
     references = ["안녕하세요"]


### PR DESCRIPTION
## Summary
- remove stray blank line before `test_compute_metrics_simple` to ensure it's recognized as a separate test

## Testing
- `pytest -k test_compute_metrics_simple -q`

------
https://chatgpt.com/codex/tasks/task_e_684121729a108333bb69dacef21b6485