### PR TITLE
Fix cloud batch loading

### DIFF
--- a/format/to_parquet.py
+++ b/format/to_parquet.py
@@ -178,6 +178,7 @@ def get_total_lines(file_path: str) -> int:
 def convert_jsonl_to_parquet(input_file: str, output_file: str, config: Dict, batch_size: int = 1000):
     """
     Convert JSONL file to Parquet format
+    using a cloud storage client for reading
 
     Args:
         input_file: Path to input JSONL file
@@ -186,6 +187,9 @@ def convert_jsonl_to_parquet(input_file: str, output_file: str, config: Dict, ba
         batch_size: Batch size for processing
     """
     logger = logging.getLogger(__name__)
+
+    # Initialize cloud storage client
+    storage_client = get_storage_client(config)
 
     # Get schema configuration
     schema_config = config.get('schema', {})
@@ -204,8 +208,10 @@ def convert_jsonl_to_parquet(input_file: str, output_file: str, config: Dict, ba
 
     with tqdm(total=total_lines, desc="Converting to Parquet") as pbar:
         while processed_lines < total_lines:
-            # Load batch
-            documents = load_jsonl_batch(input_file, batch_size, processed_lines)
+            # Load batch from cloud storage
+            documents = load_jsonl_batch_from_cloud(
+                storage_client, input_file, batch_size, processed_lines
+            )
 
             if not documents:
                 break

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -5,9 +5,31 @@ import pytest
 pytest.importorskip("pandas")
 pytest.importorskip("pyarrow")
 
-from format.to_parquet import main as to_parquet_main  # type: ignore
+from format.to_parquet import (
+    main as to_parquet_main,
+    load_jsonl_batch_from_cloud,
+)
+from unittest.mock import MagicMock
 
 
 def test_to_parquet_exists() -> None:
     """Ensure conversion entrypoint exists."""
     assert callable(to_parquet_main)
+
+
+def test_load_jsonl_batch_from_cloud() -> None:
+    """Verify batch loading with a storage client."""
+    docs = [
+        {"text": "a"},
+        {"text": "b"},
+        {"text": "c"},
+    ]
+
+    storage_client = MagicMock()
+    storage_client.read_jsonl_file.return_value = iter(docs)
+
+    batch = load_jsonl_batch_from_cloud(
+        storage_client, "s3://bucket/file.jsonl", batch_size=2, start_line=1
+    )
+
+    assert batch == docs[1:3]


### PR DESCRIPTION
## Summary
- create a cloud storage client inside `convert_jsonl_to_parquet`
- read documents via `load_jsonl_batch_from_cloud`
- test loading batches from a mocked cloud client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841217205a883338afe0c8786249831