### PR TITLE
Document dependency installation and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          PYTHONPATH=. pytest -q

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ cd YunMin-efficient-data
 # 환경 자동 설정 (Python 3.8+ 필요)
 chmod +x scripts/setup_env.sh
 ./scripts/setup_env.sh
-
+# 스크립트는 requirements.txt 의 모든 패키지를 자동으로 설치합니다.
+# 가상환경을 직접 만든 경우 다음 명령으로 의존성을 설치할 수 있습니다.
+# pip install -r requirements.txt
 # 가상환경 활성화
 source venv/bin/activate  # Linux/Mac
 # 또는 venv\Scripts\activate  # Windows


### PR DESCRIPTION
## Summary
- document installing requirements in the quick start guide
- add CI workflow installing dependencies and running pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841217508748333a3666df1c5b203e7