### PR TITLE
Improve JSONL streaming validation

### DIFF
--- a/dedup/slimpajama_dedup.py
+++ b/dedup/slimpajama_dedup.py
@@ -25,7 +25,11 @@ from .minhash_utils import (
 import redis
 from .cluster_reduction import select_representative_document
 from utils.cloud_storage import get_storage_client
-from utils.data_utils import validate_jsonl_format
+from utils.data_utils import (
+    validate_jsonl_format,
+    validate_json,
+    normalize_document,
+)
 
 
 def setup_logging():
@@ -303,13 +307,41 @@ def main():
 
         logger.info(f"Cloud input file is valid with {total_lines} documents")
 
-        # Load documents from cloud storage
-        logger.info("Loading documents from cloud storage...")
+        # Stream and validate documents line by line
+        logger.info("Streaming and validating documents...")
+        required_fields = config.get("schema", {}).get("required_columns", ["text"])
         documents = []
-        for doc in storage_client.read_jsonl_file(args.input):
-            documents.append(doc)
+        valid_lines: list[str] = []
+        valid_count = 0
+        invalid_count = 0
+        for doc in storage_client.stream_jsonl(args.input):
+            is_valid, err = validate_json(doc, required_fields)
+            if is_valid:
+                cleaned = normalize_document(doc)
+                documents.append(cleaned)
+                valid_lines.append(json.dumps(cleaned, ensure_ascii=False))
+                valid_count += 1
+            else:
+                invalid_count += 1
 
-        logger.info(f"Loaded {len(documents)} documents from cloud storage")
+        logger.info(
+            "Validation finished: %d valid lines, %d invalid lines",
+            valid_count,
+            invalid_count,
+        )
+
+        # Save cleaned lines to dedup_ready
+        dedup_ready_dir = config.get("paths", {}).get("dedup_ready", "data/dedup_ready/")
+        ready_path = os.path.join(dedup_ready_dir, Path(args.input).name)
+        ready_content = "\n".join(valid_lines)
+        storage_client.write_text_file(ready_path, ready_content)
+
+        # Save preview of first five documents
+        preview_path = os.path.join(dedup_ready_dir, "sample_preview.json")
+        storage_client.write_text_file(
+            preview_path,
+            json.dumps(documents[:5], ensure_ascii=False, indent=2),
+        )
 
         # Build MinHash index
         lsh, minhashes = build_minhash_index(documents, config)

--- a/tests/test_cloud_storage.py
+++ b/tests/test_cloud_storage.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 
 from utils.cloud_storage import CloudStorageManager, get_storage_client
-from utils.data_utils import validate_jsonl_format
+from utils.data_utils import validate_jsonl_format, validate_json
 
 
 class TestCloudStorageManager(unittest.TestCase):
@@ -189,6 +189,17 @@ class TestDataUtils(unittest.TestCase):
         self.assertEqual(info['valid_lines'], 2)
         self.assertEqual(info['invalid_lines'], 1)
         self.assertGreater(len(info['validation_errors']), 0)
+
+    def test_validate_json(self):
+        """Validate a single JSON object"""
+        doc = {"text": "sample", "source": "test"}
+        is_valid, err = validate_json(doc, ["text", "source"])
+        self.assertTrue(is_valid)
+        self.assertEqual(err, "")
+
+        invalid_doc = {"text": ""}
+        is_valid, err = validate_json(invalid_doc, ["text", "source"])
+        self.assertFalse(is_valid)
 
 
 class TestGetStorageClient(unittest.TestCase):

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -5,12 +5,13 @@ This module provides cloud storage and common utility functions.
 """
 
 from .cloud_storage import CloudStorageManager, get_storage_client
-from .data_utils import validate_jsonl_format, get_file_info
+from .data_utils import validate_jsonl_format, validate_json, get_file_info
 
 __version__ = "1.0.0"
 __all__ = [
     "CloudStorageManager",
     "get_storage_client",
     "validate_jsonl_format",
+    "validate_json",
     "get_file_info"
 ]

--- a/utils/data_utils.py
+++ b/utils/data_utils.py
@@ -6,7 +6,7 @@ Common data validation and processing functions
 
 import json
 import logging
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 import re
 
@@ -93,6 +93,34 @@ def contains_korean(text: str) -> bool:
     """
     korean_pattern = re.compile(r'[\uac00-\ud7af\u1100-\u11ff\u3130-\u318f]')
     return bool(korean_pattern.search(text))
+
+
+def validate_json(data: Any, required_fields: list[str] | None = None) -> tuple[bool, str]:
+    """Validate a single JSON object.
+
+    Parameters
+    ----------
+    data : Any
+        Parsed JSON data to validate.
+    required_fields : list[str] | None, optional
+        Fields that must be present and not empty.
+
+    Returns
+    -------
+    tuple[bool, str]
+        ``(True, "")`` if valid, otherwise ``(False, reason)``.
+    """
+
+    if not isinstance(data, dict):
+        return False, "Not a JSON object"
+
+    if required_fields:
+        for field in required_fields:
+            value = data.get(field)
+            if value is None or value == "" or value == []:
+                return False, f"Missing or empty field: {field}"
+
+    return True, ""
 
 
 def validate_document_schema(doc: Dict, required_fields: List[str]) -> Tuple[bool, List[str]]:


### PR DESCRIPTION
## Summary
- validate single JSON object with new `validate_json` helper
- stream input JSONL in `slimpajama_dedup.py` and save cleaned preview
- expose `validate_json` in utils
- add unit test for JSON validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684143ace59883338c5f342befc15fcd