### PR TITLE
Add candidate pair logging

### DIFF
--- a/dedup/mapreduce_dedup_driver.py
+++ b/dedup/mapreduce_dedup_driver.py
@@ -23,7 +23,7 @@ def _process_chunk(args: tuple[List[str], Dict]) -> List[Dict]:
     lines, config = args
     docs = [json.loads(line) for line in lines if line.strip()]
     lsh, minhashes = build_minhash_index(docs, config)
-    clusters = find_duplicate_clusters(lsh, minhashes)
+    clusters, _ = find_duplicate_clusters(lsh, minhashes)
     deduped, _ = deduplicate_documents(docs, clusters)
     return deduped
 


### PR DESCRIPTION
## Summary
- track candidate pairs returned by LSH queries
- allow CLI flags to control output paths
- write candidate pairs and dedup log to cloud storage
- fix mapreduce driver for new return value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_684143ae1efc83339220b795cbd8bf22