### PR TITLE
Implement LoRA training workflow

### DIFF
--- a/format/to_parquet.py
+++ b/format/to_parquet.py
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - fallback if PyYAML missing
     yaml = None  # type: ignore
 
 from .parquet_utils import create_schema, validate_parquet_file
+from utils.cloud_storage import get_storage_client
 
 
 def setup_logging():

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -4,7 +4,8 @@ import pytest
 
 pytest.importorskip("torch")
 
-import torch
+import yaml
+from pathlib import Path
 
 from dem.train_individual import train_individual_domain
 from dem.vector_diff import compute_vector_diff
@@ -18,23 +19,36 @@ def test_dem_functions_exist() -> None:
     assert callable(merge_models)
 
 
-def test_training_diff_and_merge() -> None:
-    """Run a tiny end-to-end cycle on toy tensors."""
+def test_training_creates_artifacts(tmp_path) -> None:
+    """Run a tiny LoRA training and ensure files are written."""
 
-    x = torch.eye(2)
-    y = 2 * torch.eye(2)
+    data_file = tmp_path / "data.jsonl"
+    data_file.write_text('{"text": "hello"}\n{"text": "world"}\n', encoding="utf-8")
+    config = {
+        "base_model": {"name": "hf-internal-testing/tiny-random-gpt2"},
+        "training": {"learning_rate": 1e-4, "batch_size": 1, "max_epochs": 1},
+        "lora": {"r": 2, "alpha": 4, "dropout": 0.0, "target_modules": ["c_attn"]},
+    }
+    config_path = tmp_path / "cfg.yaml"
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(config, f)
 
-    lora = train_individual_domain(x, y, epochs=5, lr=0.2, use_fsdp=False, mlflow_run="test")
-    assert "lora_weight" in lora
+    model_dir = tmp_path / "model"
+    log_dir = tmp_path / "logs"
+    summary_dir = tmp_path / "summary"
 
-    base = {"lora_weight": torch.zeros_like(lora["lora_weight"])}
+    adapter = train_individual_domain(
+        str(data_file),
+        "demo",
+        config_path=str(config_path),
+        output_dir=str(model_dir),
+        log_dir=str(log_dir),
+        summary_dir=str(summary_dir),
+    )
 
-    diff = compute_vector_diff(base, lora)
-    for param in diff.values():
-        assert not torch.all(param == 0)
-
-    merged = merge_models(base, [(diff, 1.0)])
-    assert torch.allclose(merged["lora_weight"], lora["lora_weight"], atol=1e-2)
+    assert Path(adapter).exists()
+    assert (log_dir / "train_demo.log").exists()
+    assert (summary_dir / "train_demo.csv").exists()
 
 def test_compute_vector_diff_basic() -> None:
     """Verify simple difference calculation between two models."""
@@ -55,15 +69,3 @@ def test_merge_models_additive() -> None:
 
     expected = {"w1": 1.1, "w2": 1.8}
     assert merged == expected
-
-
-def test_train_individual_domain_creates_output(tmp_path) -> None:
-    """Training function should create the given output directory."""
-    data_file = tmp_path / "sample.jsonl"
-    data_file.write_text('{"text": "hello"}\n', encoding="utf-8")
-    out_dir = tmp_path / "model"
-
-    result = train_individual_domain(str(data_file), str(out_dir), mlflow_run="file")
-
-    assert out_dir.exists()
-    assert result is not None

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -6,7 +6,6 @@ pytest.importorskip("torch")
 
 import yaml
 from pathlib import Path
-import torch
 import subprocess
 import sys
 import json


### PR DESCRIPTION
## Summary
- implement real LoRA fine‑tuning in `train_individual_domain`
- use tiny tokenizer and model for tests
- fix missing import in `format/to_parquet`
- update tests for new workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684143b27880833384b0901bba0a1291