### PR TITLE
Add CLI for diff vectors with stats

### DIFF
--- a/dem/__init__.py
+++ b/dem/__init__.py
@@ -1,12 +1,13 @@
 """YunMin-EfficientData DEM (Data Efficiency Method) Module."""
 
 from .train_individual import train_individual_domain
-from .vector_diff import compute_vector_diff
+from .vector_diff import compute_vector_diff, compute_stats
 from .merge_model import merge_models
 
 __version__ = "1.0.0"
 __all__ = [
     "train_individual_domain",
     "compute_vector_diff",
+    "compute_stats",
     "merge_models",
 ]

--- a/dem/vector_diff.py
+++ b/dem/vector_diff.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Dict
 
+import argparse
+import json
+from pathlib import Path
+
 import torch
+import numpy as np
 
 
 def compute_vector_diff(
@@ -18,3 +23,57 @@ def compute_vector_diff(
         tuned_param = fine_tuned_model[name]
         diff[name] = tuned_param - base_param
     return diff
+
+
+def compute_stats(diff: Dict[str, torch.Tensor]) -> Dict[str, float]:
+    """Return norm, max and min values of all tensors in ``diff``."""
+
+    if not diff:
+        return {"norm": 0.0, "max": 0.0, "min": 0.0}
+
+    arr = np.concatenate([t.detach().cpu().numpy().ravel() for t in diff.values()])
+    return {
+        "norm": float(np.linalg.norm(arr)),
+        "max": float(np.max(arr)),
+        "min": float(np.min(arr)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute parameter diff vector between base and LoRA models."
+    )
+    parser.add_argument("--base", required=True, help="Path to base model file")
+    parser.add_argument("--lora", required=True, help="Path to LoRA model file")
+    parser.add_argument("--domain", required=True, help="Domain identifier")
+    parser.add_argument(
+        "--diff-dir", default="diff_vectors", help="Directory to save diff .npy"
+    )
+    parser.add_argument(
+        "--stats-dir", default="diff_stats", help="Directory to save stats JSON"
+    )
+    args = parser.parse_args()
+
+    base = torch.load(args.base, map_location="cpu")
+    lora = torch.load(args.lora, map_location="cpu")
+
+    diff = compute_vector_diff(base, lora)
+
+    diff_dir = Path(args.diff_dir)
+    diff_dir.mkdir(parents=True, exist_ok=True)
+    diff_path = diff_dir / f"diff_{args.domain}.npy"
+    np.save(diff_path, {k: v.detach().cpu().numpy() for k, v in diff.items()})
+
+    stats = compute_stats(diff)
+    stats_dir = Path(args.stats_dir)
+    stats_dir.mkdir(parents=True, exist_ok=True)
+    stats_path = stats_dir / f"{args.domain}_summary.json"
+    with stats_path.open("w", encoding="utf-8") as f:
+        json.dump(stats, f, ensure_ascii=False, indent=2)
+
+    print(f"Diff vector saved to {diff_path}")
+    print(f"Stats saved to {stats_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -5,9 +5,13 @@ import pytest
 pytest.importorskip("torch")
 
 import torch
+import subprocess
+import sys
+import json
+import numpy as np
 
 from dem.train_individual import train_individual_domain
-from dem.vector_diff import compute_vector_diff
+from dem.vector_diff import compute_vector_diff, compute_stats
 from dem.merge_model import merge_models
 
 
@@ -67,3 +71,52 @@ def test_train_individual_domain_creates_output(tmp_path) -> None:
 
     assert out_dir.exists()
     assert result is not None
+
+
+def test_vector_diff_cli_creates_files(tmp_path) -> None:
+    """CLI should save diff numpy and stats JSON."""
+
+    base = {"w": torch.zeros(1, 1)}
+    lora = {"w": torch.ones(1, 1)}
+
+    base_path = tmp_path / "base.pt"
+    lora_path = tmp_path / "lora.pt"
+    torch.save(base, base_path)
+    torch.save(lora, lora_path)
+
+    diff_dir = tmp_path / "diff"
+    stats_dir = tmp_path / "stats"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "dem.vector_diff",
+        "--base",
+        str(base_path),
+        "--lora",
+        str(lora_path),
+        "--domain",
+        "demo",
+        "--diff-dir",
+        str(diff_dir),
+        "--stats-dir",
+        str(stats_dir),
+    ]
+
+    subprocess.run(cmd, check=True)
+
+    diff_file = diff_dir / "diff_demo.npy"
+    stats_file = stats_dir / "demo_summary.json"
+
+    assert diff_file.exists()
+    assert stats_file.exists()
+
+    diff = np.load(diff_file, allow_pickle=True).item()
+    assert diff["w"][0, 0] == 1.0
+
+    with stats_file.open("r", encoding="utf-8") as f:
+        stats = json.load(f)
+
+    for key in ["norm", "max", "min"]:
+        assert key in stats
+


### PR DESCRIPTION
## Summary
- add command-line interface to compute diff vectors and stats
- write statistics to `diff_stats` directory
- test CLI file creation
- provide fallback imports in dedup utilities for minimal test deps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684143b3a3d883338aba54b9af98a35d