### PR TITLE
Add CLI for model merging and evaluation comparison

### DIFF
--- a/dem/merge_model.py
+++ b/dem/merge_model.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Dict, Iterable, Tuple
+from typing import Dict, Iterable, Tuple, List
 from decimal import Decimal
+import argparse
+from pathlib import Path
 
 import torch
 
@@ -31,7 +33,75 @@ def merge_models(
     }
 
 
+def load_state_dict(path: str) -> Dict[str, torch.Tensor]:
+    """Load a PyTorch state dict from ``path`` on CPU."""
+    return torch.load(path, map_location="cpu")
+
+
+def save_state_dict(path: str, state_dict: Dict[str, torch.Tensor]) -> None:
+    """Save ``state_dict`` to ``path`` creating parent directories."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(state_dict, out)
+
+
+def parse_diff_arg(arg: str) -> tuple[str, float]:
+    """Return diff vector path and weight from ``PATH:WEIGHT`` string."""
+    try:
+        path, weight = arg.split(":")
+        return path, float(weight)
+    except ValueError as exc:  # pragma: no cover - simple parsing
+        raise argparse.ArgumentTypeError(
+            "Diff argument must be in PATH:WEIGHT format"
+        ) from exc
+
+
+def main() -> None:  # pragma: no cover - CLI
+    parser = argparse.ArgumentParser(description="Merge diff vectors and run evaluation")
+    parser.add_argument("--base-model", default="models/base/pytorch_model.bin", help="Path to base model weights")
+    parser.add_argument("--output-dir", default="models/merged", help="Directory to save merged model")
+    parser.add_argument(
+        "--diff",
+        action="append",
+        required=True,
+        help="Diff vector and weight in PATH:WEIGHT format; can be repeated",
+    )
+    parser.add_argument(
+        "--prompt-file",
+        default="evaluation/eval_prompts.jsonl",
+        help="Prompts for comparison after merging",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        default="eval/eval_prompt_comparison.md",
+        help="Markdown file to write prompt comparison",
+    )
+    args = parser.parse_args()
+
+    base = load_state_dict(args.base_model)
+
+    diffs: List[Tuple[Dict[str, torch.Tensor], float]] = []
+    for d in args.diff:
+        path, weight = parse_diff_arg(d)
+        diffs.append((load_state_dict(path), weight))
+
+    merged = merge_models(base, diffs)
+
+    out_path = Path(args.output_dir) / "pytorch_model.bin"
+    save_state_dict(str(out_path), merged)
+
+    # Run evaluation to create markdown comparison
+    from evaluation.eval_runner import save_prompt_comparison
+
+    save_prompt_comparison(
+        args.base_model,
+        args.output_dir,
+        args.prompt_file,
+        args.markdown_out,
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover - manual usage
-    merge_models({}, [])
+    main()
 
 

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -134,9 +134,10 @@ run_phase3() {
     # Merge models
     log_message "Merging models..."
     python -m dem.merge_model \
-        --config "$DEM_CONFIG" \
-        --diff-vectors-dir "models/diff_vectors" \
+        --base-model "models/base/pytorch_model.bin" \
         --output-dir "models/merged" \
+        --diff "models/diff_vectors/domain1.pt:1.0" \
+        --diff "models/diff_vectors/domain2.pt:1.0" \
         2>> "$ERROR_LOG"
 
     validate_phase "3" "models/merged/pytorch_model.bin"
@@ -150,8 +151,9 @@ run_phase4() {
     python -m evaluation.eval_runner \
         --base-model "models/base/" \
         --merged-model "models/merged/" \
-        --eval-prompts "evaluation/eval_prompts.jsonl" \
-        --output-dir "results/" \
+        --prompts "evaluation/eval_prompts.jsonl" \
+        --output "results/evaluation_metrics.json" \
+        --md-output "eval/eval_prompt_comparison.md" \
         2>> "$ERROR_LOG"
 
     # Compute metrics

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,7 +8,7 @@ pytest.importorskip("bert_score")
 pytest.importorskip("rouge_score")
 pytest.importorskip("sacrebleu")
 
-from evaluation.eval_runner import run_evaluation
+from evaluation.eval_runner import run_evaluation, save_prompt_comparison
 from evaluation.compute_metrics import compute_metrics
 
 
@@ -91,4 +91,17 @@ def test_run_evaluation_no_reference_uses_base_outputs() -> None:
         run_evaluation("base", "merged")
 
     metric_mock.assert_called_once_with(["base"], ["merged"])
+
+
+def test_save_prompt_comparison_writes_file(tmp_path) -> None:
+    """``save_prompt_comparison`` should write markdown file."""
+
+    out_file = tmp_path / "cmp.md"
+    with patch("evaluation.eval_runner.load_prompts", return_value=[{"prompt": "p"}]), \
+         patch("evaluation.eval_runner.AutoModelForCausalLM", MagicMock()), \
+         patch("evaluation.eval_runner.AutoTokenizer", MagicMock()), \
+         patch("evaluation.eval_runner.generate_responses", side_effect=[["b"], ["m"]]):
+        save_prompt_comparison("base", "merged", "dummy.jsonl", str(out_file))
+
+    assert out_file.exists()
 


### PR DESCRIPTION
## Summary
- extend `merge_model.py` with a command line interface
- allow evaluation output generation in `eval_runner`
- update pipeline script to use the new CLI and produce markdown
- test markdown generation helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasketch')*

------
https://chatgpt.com/codex/tasks/task_e_684143b602148333bd7bde52abe6104a