### PR TITLE
Fix outdated script references in docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -79,7 +79,7 @@ YunMin-efficient-data/
 ├── scripts/                  # 실행 자동화 및 공통 유틸
 │   ├── run_pipeline.sh      # 전체 파이프라인 실행 스크립트
 │   ├── setup_env.sh         # venv, requirements 설치 스크립트
-│   └── test_loading_speed.py# parquet vs jsonl I/O 벤치마크
+│   └── tests/test_loading_speed.py # parquet vs jsonl I/O 벤치마크
 │
 ├── configs/                  # 설정 파일 저장소
 │   ├── dataset_config.yaml  # S3 경로, 열 명세, 토큰화 설정 등

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ YunMin-efficient-data/
 ├── scripts/                  # 실행 자동화 및 공통 유틸
 │   ├── run_pipeline.sh      # 전체 파이프라인 실행 스크립트
 │   ├── setup_env.sh         # venv, requirements 설치 스크립트
-│   └── test_loading_speed.py# parquet vs jsonl I/O 벤치마크
+│   └── tests/test_loading_speed.py # parquet vs jsonl I/O 벤치마크
 │
 ├── configs/                  # 설정 파일 저장소
 │   ├── dataset_config.yaml  # S3 경로, 열 명세, 토큰화 설정 등

--- a/docs/phase2.md
+++ b/docs/phase2.md
@@ -17,7 +17,7 @@
 ```
 deduped/                    # 중복 제거 완료 JSONL 데이터
  ↓
-jsonl_to_parquet.py         # 변환 스크립트
+to_parquet.py               # 변환 스크립트
  ↓
 parquet_ready/              # Parquet 형식으로 저장된 출력 파일
  ↓

--- a/docs/phase4.md
+++ b/docs/phase4.md
@@ -34,7 +34,7 @@ docs/report.md                   # 최종 성능 평가 및 요약 보고서
 
 1. **스크립트 구성**
 
-   * 각 Phase 스크립트(`dedup.py`, `jsonl_to_parquet.py`, `train_individual.py`, `merge_model.py`)를 순차 호출
+   * 각 Phase 스크립트(`slimpajama_dedup.py`, `to_parquet.py`, `train_individual.py`, `merge_model.py`)를 순차 호출
    * 환경 변수 및 데이터 경로 자동 지정 (예: `.env` 또는 argparse)
 
 2. **로그 기록**


### PR DESCRIPTION
## Summary
- update AGENTS doc to reflect new test script path
- fix architecture doc script path
- update phase2 and phase4 docs to reference `to_parquet.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842abbae564833398d51950d45e6b72